### PR TITLE
add property to menu-open event to prevent skinning

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -1548,7 +1548,7 @@ function rcube_elastic_ui()
      */
     function menu_toggle(p)
     {
-        if (!p || !p.name) {
+        if (!p || !p.name || (p.props && p.props.skinable === false)) {
             return;
         }
 


### PR DESCRIPTION
the elastic skin uses the menu-open js event to do additional skinning to menus. this gives plugins a way of preventing the skin from doing anything extra.