### PR TITLE
skip buttons which already have the Bootstrap class

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -475,7 +475,7 @@ function rcube_elastic_ui()
             context = document;
         }
 
-        $('input.button,button', context).addClass('btn').not('.btn-primary,.primary,.mainaction').addClass('btn-secondary');
+        $('input.button,button', context).not('.btn').addClass('btn').not('.btn-primary,.primary,.mainaction').addClass('btn-secondary');
         $('input.button.mainaction,button.primary,button.mainaction', context).addClass('btn-primary');
         $('button.btn.delete,button.btn.discard', context).addClass('btn-danger');
 


### PR DESCRIPTION
`bootstrap_style()` in ui.js adds .btn-secondary to any button that is not a primary but plugins might want to use another kind of button, such as btn-danger. a simple solution is to assume anything which already has the `btn` class does not need any extra classes.