### PR TITLE
Fix login form display on IE and Chrome

### DIFF
--- a/styles/styles.less
+++ b/styles/styles.less
@@ -146,7 +146,7 @@ a.disabled:not(.btn) {
 
 #login-form {
     margin: 0 auto;
-    top: 35%;
+    top: 35vh;
     width: 95%;
     max-width: 280px;
     position: relative;


### PR DESCRIPTION
Use viewport height for defining the margin-top.